### PR TITLE
Feat: Save and Show Image

### DIFF
--- a/app/src/api/axios.js
+++ b/app/src/api/axios.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { auth } from '../constants/firebase';
 
 export const apiClient = axios.create({
-  baseURL: process.env.REACT_APP_QU_BASE_API,
-  // baseURL: process.env.REACT_APP_QU_LOCAL_API,
+  baseURL:
+    process.env.REACT_APP_QU_BASE_API || process.env.REACT_APP_QU_LOCAL_API,
 });
 
 export const createToken = async () => {

--- a/app/src/components/AnswersModal/index.jsx
+++ b/app/src/components/AnswersModal/index.jsx
@@ -49,6 +49,8 @@ const AnswersModal = props => {
     return <span className="question-countdown">{timer}</span>;
   };
 
+  const questionName = questions[questionIndex].question.name;
+  const questionImageSrc = questions[questionIndex].question.image ?? null;
   return (
     <Modal
       centered
@@ -61,9 +63,14 @@ const AnswersModal = props => {
       visible={visible}>
       <div className="question-wrapper">
         {(published || isDesktopOrBigger) && RENDERER()}
-        <p className="question-content">
-          {questions[questionIndex].question.name}
-        </p>
+        <p className="question-content">{questionName}</p>
+        {/* TODO: make image responsive and 
+        confirm if we want this to render on mobile */}
+        {ANSWERS.length === 0 && questionImageSrc ? (
+          <div>
+            <img src={questionImageSrc} alt={questionName} />
+          </div>
+        ) : null}
         <div className="answers-table">
           {ANSWERS.length > 0 && (
             <div className="answers-header">

--- a/app/src/containers/Game/index.jsx
+++ b/app/src/containers/Game/index.jsx
@@ -68,8 +68,9 @@ const Game = props => {
 
   //connect-disconect to socket
   useEffect(() => {
-    socket.current = io(process.env.REACT_APP_QU_BASE_API);
-    // socket.current = io(process.env.REACT_APP_QU_LOCAL_API);
+    socket.current = io(
+      process.env.REACT_APP_QU_BASE_API || process.env.REACT_APP_QU_LOCAL_API
+    );
     socket.current.on('connect', () => {
       setSocketConnected(true);
     });

--- a/app/src/state/initialState.js
+++ b/app/src/state/initialState.js
@@ -55,9 +55,11 @@ export const initialState = {
     name: '',
     categories: [],
     points: 100,
+    image: '',
     errorName: false,
     errorCategories: false,
     errorPoints: false,
+    errorImage: false,
     isBonus: false,
   },
   teams: {

--- a/pwa/src/api/axios.js
+++ b/pwa/src/api/axios.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { auth } from '../helpers/firebase';
 
 export const apiClient = axios.create({
-  baseURL: process.env.REACT_APP_QU_BASE_API,
-  // baseURL: process.env.REACT_APP_QU_LOCAL_API,
+  baseURL:
+    process.env.REACT_APP_QU_BASE_API || process.env.REACT_APP_QU_LOCAL_API,
 });
 
 export const createToken = async () => {

--- a/pwa/src/helpers/socket.js
+++ b/pwa/src/helpers/socket.js
@@ -3,8 +3,9 @@ let socket;
 
 let rID;
 export const initiateSocket = (roomId, teamName) => {
-  socket = io(process.env.REACT_APP_QU_BASE_API);
-  // socket = io(process.env.REACT_APP_QU_LOCAL_API);
+  socket = io(
+    process.env.REACT_APP_QU_BASE_API || process.env.REACT_APP_QU_LOCAL_API
+  );
   rID = roomId;
   if (socket && roomId) {
     socket.on('connect', () => {

--- a/server/package.json
+++ b/server/package.json
@@ -1,42 +1,41 @@
 {
-    "name": "quiz-up",
-    "version": "1.0.0",
-    "engines": {
-        "node": "10.16.0"
-    },
-    "description": "Manager for panel based question games",
-    "main": "index.js",
-    "scripts": {
-        "start": "npm run build-windows && node dist/src/index.js",
-        "dev": "babel-watch -L ./src/index.js",
-        "build": "rm -rf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules",
-        "clean": "rimraf dist",
-        "build-windows": "npm run clean && babel ./ --out-dir dist/ --ignore ./node_modules"
-    },
-    "keywords": [],
-    "author": "ECT PUCMM",
-    "license": "ISC",
-    "dependencies": {
-        "@babel/cli": "7.12.1",
-        "@babel/core": "7.9.0",
-        "@babel/polyfill": "7.8.7",
-        "@babel/preset-env": "7.9.0",
-        "@hapi/joi": "17.1.0",
-        "amqplib": "0.5.5",
-        "body-parser": "1.19.0",
-        "cors": "^2.8.5",
-        "dotenv": "8.2.0",
-        "express": "4.17.1",
-        "firebase-admin": "^9.3.0",
-        "helmet": "^4.2.0",
-        "joi-objectid": "3.0.1",
-        "lodash": "^4.17.20",
-        "mongoose": "5.8.11",
-        "morgan": "^1.10.0",
-        "rimraf": "^3.0.2",
-        "socket.io": "^2.3.0"
-    },
-    "devDependencies": {
-        "babel-watch": "7.0.0"
-    }
+  "name": "quiz-up",
+  "version": "1.0.0",
+  "engines": {
+    "node": "10.16.0"
+  },
+  "description": "Manager for panel based question games",
+  "main": "index.js",
+  "scripts": {
+    "start": "npm run build && node dist/src/index.js",
+    "dev": "babel-watch -L ./src/index.js",
+    "clean": "rimraf dist",
+    "build": "npm run clean && babel ./ --out-dir dist/ --ignore ./node_modules"
+  },
+  "keywords": [],
+  "author": "ECT PUCMM",
+  "license": "ISC",
+  "dependencies": {
+    "@babel/cli": "7.12.1",
+    "@babel/core": "7.9.0",
+    "@babel/polyfill": "7.8.7",
+    "@babel/preset-env": "7.9.0",
+    "@hapi/joi": "17.1.0",
+    "amqplib": "0.5.5",
+    "body-parser": "1.19.0",
+    "cors": "^2.8.5",
+    "dotenv": "8.2.0",
+    "express": "4.17.1",
+    "firebase-admin": "^9.3.0",
+    "helmet": "^4.2.0",
+    "joi-objectid": "3.0.1",
+    "lodash": "^4.17.20",
+    "mongoose": "5.8.11",
+    "morgan": "^1.10.0",
+    "rimraf": "^3.0.2",
+    "socket.io": "^2.3.0"
+  },
+  "devDependencies": {
+    "babel-watch": "7.0.0"
+  }
 }

--- a/server/src/rest/components/question/model.js
+++ b/server/src/rest/components/question/model.js
@@ -60,7 +60,7 @@ const Question = new Schema({
  */
 export function validateQuestion(question) {
   const schema = Joi.object({
-    name: Joi.string().min(4).max(255).required(),
+    name: Joi.string().min(4).required(),
     categories: Joi.array(),
     points: Joi.number().min(100).max(500).required(),
     image: Joi.string(),
@@ -74,7 +74,7 @@ export function validateQuestion(question) {
 
 export function validateForUpdate(question) {
   const schema = Joi.object({
-    name: Joi.string().min(4).max(255),
+    name: Joi.string().min(4),
     categories: Joi.array(),
     points: Joi.number().min(100).max(500),
     image: Joi.string(),

--- a/server/src/rest/components/question/model.js
+++ b/server/src/rest/components/question/model.js
@@ -4,44 +4,49 @@ import Joi from '@hapi/joi';
 const Schema = moongose.Schema;
 
 const Question = new Schema({
-    name: {
-        type: String,
-        required: true,
-        minlength: 4,
-        maxlength: 255,
+  name: {
+    type: String,
+    required: true,
+    minlength: 4,
+  },
+  categories: [
+    {
+      type: String,
+      required: true,
     },
-    categories: [{
-        type: String,
-        required: true,
-    }, ],
-    points: {
-        type: Number,
-        required: true,
-        min: 100,
-        max: 500,
-        default: 100,
-    },
-    // isBonus: {
-    //   type: Boolean,
-    //   default: false,
-    // },
-    deleted: {
-        type: Boolean,
-        default: false,
-    },
-    deletedAt: {
-        type: Date,
-        default: Date.now,
-    },
-    createdBy: {
-        type: Schema.Types.ObjectId,
-        ref: 'Admin',
-    },
-    createdAt: {
-        type: Date,
-        required: true,
-        default: Date.now,
-    },
+  ],
+  points: {
+    type: Number,
+    required: true,
+    min: 100,
+    max: 500,
+    default: 100,
+  },
+  image: {
+    type: String,
+    default: '',
+  },
+  // isBonus: {
+  //   type: Boolean,
+  //   default: false,
+  // },
+  deleted: {
+    type: Boolean,
+    default: false,
+  },
+  deletedAt: {
+    type: Date,
+    default: Date.now,
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'Admin',
+  },
+  createdAt: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
 });
 
 /**
@@ -54,28 +59,30 @@ const Question = new Schema({
  * https://github.com/hapijs/joi/blob/v13.1.2/API.md#validatevalue-schema-options-callback
  */
 export function validateQuestion(question) {
-    const schema = Joi.object({
-        name: Joi.string().min(4).max(255).required(),
-        categories: Joi.array(),
-        points: Joi.number().min(100).max(500).required(),
-        // isBonus: Joi.boolean(),
-        deleted: Joi.boolean(),
-        createdBy: Joi.objectId(),
-    }).options({ stripUnknown: true });
+  const schema = Joi.object({
+    name: Joi.string().min(4).max(255).required(),
+    categories: Joi.array(),
+    points: Joi.number().min(100).max(500).required(),
+    image: Joi.string(),
+    // isBonus: Joi.boolean(),
+    deleted: Joi.boolean(),
+    createdBy: Joi.objectId(),
+  }).options({ stripUnknown: true });
 
-    return schema.validate(question);
+  return schema.validate(question);
 }
 
 export function validateForUpdate(question) {
-    const schema = Joi.object({
-        name: Joi.string().min(4).max(255),
-        categories: Joi.array(),
-        points: Joi.number().min(100).max(500),
-        deleted: Joi.boolean(),
-        deletedAt: Joi.date(),
-    }).options({ stripUnknown: true });
+  const schema = Joi.object({
+    name: Joi.string().min(4).max(255),
+    categories: Joi.array(),
+    points: Joi.number().min(100).max(500),
+    image: Joi.string(),
+    deleted: Joi.boolean(),
+    deletedAt: Joi.date(),
+  }).options({ stripUnknown: true });
 
-    return schema.validate(question);
+  return schema.validate(question);
 }
 
 export default moongose.model('Question', Question);

--- a/server/src/rest/components/round/controller.js
+++ b/server/src/rest/components/round/controller.js
@@ -66,7 +66,7 @@ const findById = async (req, res) => {
     Round.findById({ _id: req.params.id }).populate([
       {
         path: 'questions.question',
-        select: 'name points',
+        select: 'name points image',
       },
       {
         path: 'participants.failed',


### PR DESCRIPTION
# Description

- Adds an `image` field to the `Question` model and to the `Joi` functions
- dispatches the new `image` field in the frontend to the global state and saves it on the API

---
**NOTE:** took the liberty to make changes not pertaining to the image work, such as
- Improves the `server/package.json > scripts` to handle multiple developers working on a different OS
- Makes it easier to change from a local API/server to a hosted one

## Type of change

<!-- Do not mark the options that are not relevant. -->

- [ ] Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] This change requires a documentation update
- [ ] Code refactor


## Images

**TODO**: Make the image response and confirm if we want to render on the mobile controller

| With image | With no image |
|:---:|:---:|
| ![Screen Shot 2022-05-09 at 11 44 45 PM](https://user-images.githubusercontent.com/38137788/167538658-77523fb2-6751-42b0-99ed-be043c01daeb.png) | ![Screen Shot 2022-05-09 at 11 45 05 PM](https://user-images.githubusercontent.com/38137788/167538680-158b3e91-e61c-423a-80d7-9abeed338c92.png) | 